### PR TITLE
staging is deployed on the same server

### DIFF
--- a/deploy.php
+++ b/deploy.php
@@ -3,20 +3,41 @@ namespace Hypernode\DeployConfiguration;
 
 use function Deployer\run;
 use function Deployer\task;
+use function Deployer\currentHost;
 use function Deployer\upload;
 
 $APP_NAME = 'yourhypernodeappname';
+$PROD_HOST = sprintf('%s.hypernode.io', $APP_NAME);
+$STAG_HOST = sprintf('staging.%s.hypernode.io', $APP_NAME);
+$PROD_WEBROOT = '/data/web/apps/yourhypernodeappname.hypernode.io/current/pub';
+$STAG_WEBROOT = '/data/web/apps/staging.yourhypernodeappname.hypernode.io/current/pub';
 
-# Disable deploy:vendors. I'm not really deploying Magento, just a PHP file.
-task('deploy:vendors', static function () {});
-
-# Set up letsencrypt for appname.hypernode.io and enforce https
-task('deploy:hmv', static function () use (&$APP_NAME) {
-    run(sprintf('hypernode-manage-vhosts %s.hypernode.io --https --force-https --type generic-php --yes', $APP_NAME));
+# Disable the symlinking of /data/web/public because we're gonna be deploying both staging and prod on 1 Hypernode.
+task('deploy:disable_public', function () {
+    run("if ! test -d /data/web/public; then unlink /data/web/public; mkdir /data/web/public; fi");
+    run("echo 'Not used, see /data/web/apps/ instead' > /data/web/public/index.html;");
 });
 
+# Configure SSL and the NGINX vhost for production if we're doing a production deploy
+task('deploy:hmv_production', static function () use (&$PROD_HOST, &$PROD_WEBROOT) {
+    if (currentHost()->getHostname() == $PROD_HOST) {
+        run(sprintf('hypernode-manage-vhosts %s --https --force-https --type generic-php --yes --webroot %s', $PROD_HOST, $PROD_WEBROOT));
+    }
+});
+
+# Configure SSL and the NGINX vhost for production if we're doing a staging deploy
+task('deploy:hmv_staging', static function () use (&$STAG_HOST, &$STAG_WEBROOT) {
+    if (currentHost()->getHostname() == $STAG_HOST) {
+        run(sprintf('hypernode-manage-vhosts %s --https --force-https --type generic-php --yes --webroot %s', $STAG_HOST, $STAG_WEBROOT));
+    }
+});
+
+
 $configuration = new Configuration();
-$configuration->addDeployTask('deploy:hmv');
+$configuration->addDeployTask('deploy:disable_public');
+$configuration->addDeployTask('deploy:hmv_production');
+$configuration->addDeployTask('deploy:hmv_staging');
+
 # Just some sane defaults to exclude from the deploy
 $configuration->setDeployExclude([
     './.git',
@@ -31,8 +52,12 @@ $configuration->setDeployExclude([
     'etc/'
 ]);
 
-$productionStage = $configuration->addStage('production', sprintf('%s.hypernode.io', $APP_NAME));
-# Define the target server we're deploying to
-$productionStage->addServer(sprintf('%s.hypernode.io', $APP_NAME));
+$stagingStage = $configuration->addStage('staging', $STAG_HOST);
+# Define the target server we're deploying staging to
+$stagingStage->addServer($STAG_HOST);
+
+$productionStage = $configuration->addStage('production', $PROD_HOST);
+# Define the target server we're deploying production to
+$productionStage->addServer($PROD_HOST);
 
 return $configuration;


### PR DESCRIPTION
with this change a staging version of the site can be deployed to the same server as well as a separate deploy. to deploy production it's still the same command:
```
docker run --rm -it --env SSH_PRIVATE_KEY="$(cat ~/.ssh/yourdeploykey | base64)" -v ${PWD}:/build quay.io/hypernode/deploy:latest hypernode-deploy build -vvv

docker run --rm -it --env SSH_PRIVATE_KEY="$(cat ~/.ssh/yourdeploykey | base64)" -v ${PWD}:/build quay.io/hypernode/deploy:latest hypernode-deploy deploy production -vvv
```

but if you then want to deploy a whole separate vhost (staging.yourhypernodeappname.hypernode.io) you can run:
```
docker run --rm -it --env SSH_PRIVATE_KEY="$(cat ~/.ssh/yourdeploykey | base64)" -v ${PWD}:/build quay.io/hypernode/deploy:latest hypernode-deploy deploy staging -vvv
```

which would result in this directory structure on the server:
```
app@s2ltpy-yourhypernodeappname-magweb-cmbl:~$ find apps/
apps/
apps/staging.yourhypernodeappname.hypernode.io
apps/staging.yourhypernodeappname.hypernode.io/.dep
apps/staging.yourhypernodeappname.hypernode.io/.dep/latest_release
apps/staging.yourhypernodeappname.hypernode.io/.dep/releases_log
apps/staging.yourhypernodeappname.hypernode.io/releases
apps/staging.yourhypernodeappname.hypernode.io/releases/1
apps/staging.yourhypernodeappname.hypernode.io/releases/1/pub
apps/staging.yourhypernodeappname.hypernode.io/releases/1/pub/index.php
apps/staging.yourhypernodeappname.hypernode.io/releases/1/deployment-report.json
apps/staging.yourhypernodeappname.hypernode.io/releases/1/LICENSE.txt
apps/staging.yourhypernodeappname.hypernode.io/releases/1/README.md
apps/staging.yourhypernodeappname.hypernode.io/current
apps/staging.yourhypernodeappname.hypernode.io/shared
apps/yourhypernodeappname.hypernode.io
apps/yourhypernodeappname.hypernode.io/.dep
apps/yourhypernodeappname.hypernode.io/.dep/latest_release
apps/yourhypernodeappname.hypernode.io/.dep/releases_log
apps/yourhypernodeappname.hypernode.io/releases
apps/yourhypernodeappname.hypernode.io/releases/1
apps/yourhypernodeappname.hypernode.io/releases/1/pub
apps/yourhypernodeappname.hypernode.io/releases/1/pub/index.php
apps/yourhypernodeappname.hypernode.io/releases/1/deployment-report.json
apps/yourhypernodeappname.hypernode.io/releases/1/LICENSE.txt
apps/yourhypernodeappname.hypernode.io/releases/1/README.md
apps/yourhypernodeappname.hypernode.io/current
apps/yourhypernodeappname.hypernode.io/shared
```
with this nginx config:
```
$ grep -R root /data/web/nginx/ | grep public | grep -v varnish
/data/web/nginx/staging.hntestizanode.hypernode.io/public.genericphp.conf:root /data/web/apps/staging.hntestizanode.hypernode.io/current/pub;
/data/web/nginx/hntestizanode.hypernode.io/public.genericphp.conf:root /data/web/apps/hntestizanode.hypernode.io/current/pub;
```

The important thing to note here is that staging.myhypernode.hypernode.io is NOT deployed when myhypernode.hypernode.io is deployed and the other way around. Also the hypernode-manage-vhosts NGINX configuration command is only executed for the corresponding domain. This makes it possible to (safely) deploy both separate environments to the same server with only one deploy.php.