### PR TITLE
Add ephemeral deploy configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ And then to deploy production run:
 docker run --rm -it --env SSH_PRIVATE_KEY="$(cat ~/.ssh/yourdeploykey | base64)" -v ${PWD}:/build quay.io/hypernode/deploy:latest hypernode-deploy deploy production -vvv
 ```
 
+And to deploy an 'ephemeral' / throwaway testing environment:
+```
+$ docker run --rm -it --env HYPERNODE_API_TOKEN=yoursecretapitoken --env SSH_PRIVATE_KEY="$(cat ~/.ssh/yourdeploykey | base64)" -v ${PWD}:/build quay.io/hypernode/deploy:latest hypernode-deploy deploy testing -vvv
+```
+
 # Notes
 
 If you're testing this and you're getting:
@@ -60,3 +65,12 @@ If you're testing this and you're getting:
 ```
 
 You can log in to the Hypernode and `rm /data/web/apps/yourhypernodeappname.hypernode.io/.dep/deploy.lock` to unlock the deploy.
+
+For the API token see `/etc/hypernode/hypernode_api_token` on the Hypernode. Make sure to enable `enable plan changes via the CLI` on the `Change plan` page in the Hypernode Control Panel first. If you don't do that you'll see this message:
+
+```
+In HypernodeClient.php line 46:
+
+  [Hypernode\Api\Exception\HypernodeApiClientException (403)]
+  {"detail":"Due to the financial nature of the command, please enable api token usage on the control panel. This can be done by owner and admin roles in the Control Panel under the Change Plan menu."}
+```

--- a/README.md
+++ b/README.md
@@ -20,7 +20,12 @@ First you need to perform the build step.
 $ docker run --rm -it --env SSH_PRIVATE_KEY="$(cat ~/.ssh/yourdeploykey | base64)" -v ${PWD}:/build quay.io/hypernode/deploy:latest hypernode-deploy build -vvv
 ```
 
-Then you can perform the actual deploy by running the deploy step:
+Then you can perform the actual deploy staging by running the deploy step:
+```
+docker run --rm -it --env SSH_PRIVATE_KEY="$(cat ~/.ssh/yourdeploykey | base64)" -v ${PWD}:/build quay.io/hypernode/deploy:latest hypernode-deploy deploy staging -vvv
+```
+
+And then to deploy production run:
 ```
 docker run --rm -it --env SSH_PRIVATE_KEY="$(cat ~/.ssh/yourdeploykey | base64)" -v ${PWD}:/build quay.io/hypernode/deploy:latest hypernode-deploy deploy production -vvv
 ```


### PR DESCRIPTION
deploys a version of the site on an 'ephemeral' hypernode, which is an on-the-fly created copy of the $APP_NAME Hypernode. the `$testingStage->addEphemeralServer($APP_NAME)` step uses the [hypernode-api-php](https://github.com/ByteInternet/hypernode-api-php) client library for the Hypernode API to create that disposable environment.

the test environment can be deployed like:
```
$ docker run --rm -it --env HYPERNODE_API_TOKEN=$HYPERNODE_API_TOKEN --env SSH_PRIVATE_KEY="$(cat ~/.ssh/yourdeploykey | base64)" -v ${PWD}:/build quay.io/hypernode/deploy:latest hypernode-deploy deploy test -vvv
```