### PR TITLE
add example of deploying to hypernode-docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,15 @@ And then to deploy production run:
 docker run --rm -it --env SSH_PRIVATE_KEY="$(cat ~/.ssh/yourdeploykey | base64)" -v ${PWD}:/build quay.io/hypernode/deploy:latest hypernode-deploy deploy production -vvv
 ```
 
-And to deploy an 'ephemeral' / throwaway testing environment:
+And to deploy an 'brancher' / throwaway testing environment:
 ```
 $ docker run --rm -it --env HYPERNODE_API_TOKEN=yoursecretapitoken --env SSH_PRIVATE_KEY="$(cat ~/.ssh/yourdeploykey | base64)" -v ${PWD}:/build quay.io/hypernode/deploy:latest hypernode-deploy deploy testing -vvv
+```
+
+And to deploy to a hypernode-docker local development environment:
+```
+# Read the comment in deployer.php before you attempt to do this
+docker run --rm -it --env SSH_PRIVATE_KEY="$(cat ~/.ssh/yourdeploykey | base64)" -v ${PWD}:/build quay.io/hypernode/deploy:latest hypernode-deploy deploy docker -vvv
 ```
 
 # Notes

--- a/deploy.php
+++ b/deploy.php
@@ -9,9 +9,11 @@ use function Deployer\upload;
 $APP_NAME = 'yourhypernodeappname';
 $PROD_HOST = sprintf('%s.hypernode.io', $APP_NAME);
 $STAG_HOST = sprintf('staging.%s.hypernode.io', $APP_NAME);
+$DOCKER_HOST = '172.17.0.2';
 $PROD_WEBROOT = '/data/web/apps/yourhypernodeappname.hypernode.io/current/pub';
 $STAG_WEBROOT = '/data/web/apps/staging.yourhypernodeappname.hypernode.io/current/pub';
 $TEST_WEBROOT = '/data/web/apps/backend/current/pub';
+$DOCKER_WEBROOT = '/data/web/apps/172.17.0.2/current/pub';
 
 # Disable the symlinking of /data/web/public because we're gonna be deploying both staging and prod on 1 Hypernode.
 task('deploy:disable_public', function () {
@@ -38,8 +40,13 @@ task('deploy:hmv_staging', static function () use (&$STAG_HOST, &$STAG_WEBROOT) 
 # As a copy of the latest backup snapshot of the Hypernode $APP_NAME
 task('deploy:hmv_brancher', static function () use (&$STAG_HOST, &$PROD_HOST, &$TEST_WEBROOT) {
     if (currentHost()->getHostname() != $STAG_HOST && currentHost()->getHostname() != $PROD_HOST) {
-        run(sprintf('hypernode-manage-vhosts $(jq -r .tag /etc/hypernode/app.json).$(jq -r .hn_domain /etc/hypernode/app.json) --https --force-https --type generic-php --yes --webroot %s', $TEST_WEBROOT));
+        run(sprintf('if ! test -f /etc/hypernode/is_docker; then hypernode-manage-vhosts $(jq -r .tag /etc/hypernode/app.json).$(jq -r .hn_domain /etc/hypernode/app.json) --https --force-https --type generic-php --yes --webroot %s; fi', $TEST_WEBROOT));
     }
+});
+
+# HMV configuration for when this is running in a docker
+task('deploy:hmv_docker', static function () use (&$DOCKER_HOST, &$DOCKER_WEBROOT) {
+    run(sprintf('if test -f /etc/hypernode/is_docker; then hypernode-manage-vhosts %s --disable-https --type generic-php --yes --webroot %s --default-server; fi', $DOCKER_HOST, $DOCKER_WEBROOT));
 });
 
 
@@ -48,6 +55,7 @@ $configuration->addDeployTask('deploy:disable_public');
 $configuration->addDeployTask('deploy:hmv_production');
 $configuration->addDeployTask('deploy:hmv_staging');
 $configuration->addDeployTask('deploy:hmv_brancher');
+$configuration->addDeployTask('deploy:hmv_docker');
 
 # Just some sane defaults to exclude from the deploy
 $configuration->setDeployExclude([
@@ -82,5 +90,23 @@ $productionStage->addServer($PROD_HOST);
 $testingStage = $configuration->addStage('testing', 'backend');
 # Define the brancher target server we're deploying testing to
 $testingStage->addBrancherServer($APP_NAME);
+
+# We can also deploy to a Hypernode Docker instance. To do that you go to
+# https://github.com/byteinternet/hypernode-docker, make sure you
+# have an instance running by for example doing:
+# $ sudo docker run -P docker.hypernode.com/byteinternet/hypernode-buster-docker-php80-mysql57:latest
+# and then noting the IP address (in my case 172.17.0.2). You then
+# need to make sure your deploykey public key is added to the
+# /data/web/.ssh/authorized_keys file. Then you should be able to
+# deploy to the container as if it was a 'real' hypernode. Keep in
+# mind that the hypernode-docker is not a real VM, it's just a fat
+# container. This means that there won't be an init system (no systemd)
+# so the processes are running in SCREENs. Also obviously you can not use
+# some of the hypernode command-line functionality that depends on the
+# Hypernode API (it's not a server managed by the Hypernode automation,
+# just a local container running on your PC).
+$dockerStage = $configuration->addStage('docker', $DOCKER_HOST);
+# Define the target server (docker instance) we're deploying to
+$dockerStage->addServer($DOCKER_HOST);
 
 return $configuration;


### PR DESCRIPTION
We can also deploy to a Hypernode Docker instance. To do that you go to https://github.com/byteinternet/hypernode-docker, make sure you have an instance running by for example doing:
```
$ sudo docker run -P docker.hypernode.com/byteinternet/hypernode-buster-docker-php80-mysql57:latest
```
and then noting the IP address (in my case 172.17.0.2). You then need to make sure your deploykey public key is added to the /data/web/.ssh/authorized_keys file. Then you should be able to deploy to the container as if it was a 'real' hypernode.

Keep in mind that the hypernode-docker is not a real VM, it's just a fat container. This means that there won't be an init system (no systemd) so the processes are running in SCREENs. Also obviously you can not use some of the hypernode command-line functionality that depends on the Hypernode API (it's not a server managed by the Hypernode automation, just a local container running on your PC).

Note that Hypernode Deploy wouldn't be able to start a hypernode-docker instance for you on your host (like how it is able to start Brancher nodes on the fly) because Hypernode Deploy itself is also running in a Docker container on your host. You need to have a Hypernode Docker instance on your host running before you are able to deploy to it (on 172.17.0.2 for example, if you are on windows or mac you might need to figure out some port forwarding and use localhost).

![docker4](https://user-images.githubusercontent.com/1437341/197342360-0074e119-7292-4874-9a77-b716d89194e5.png)
![docker3](https://user-images.githubusercontent.com/1437341/197342361-f62ce19f-58f1-4479-b919-c06a6008d532.png)
![docker2](https://user-images.githubusercontent.com/1437341/197342363-cba3a35f-b98c-4a1a-b709-2d796a5c07a3.png)
![docker](https://user-images.githubusercontent.com/1437341/197342364-63bcb1e0-222a-43f7-ac77-4a46066f02b9.png)
